### PR TITLE
feat(map): 增加地图单元进度交互（mock）

### DIFF
--- a/docs/events/DEV-20260226-002-event-log.md
+++ b/docs/events/DEV-20260226-002-event-log.md
@@ -10,9 +10,13 @@
 - Parent Issue: #8
 - Child Issues: #9 #10 #11 #12
 - Branch: `feat/DEV-20260226-002-map-progress`
+- Commits:
+  - `382b1ed` feat(progress): 增加单元模型与进度状态层
+  - `3b0ecbd` feat(map): 重构地图页并接入进度交互
+  - `f987585` test(docs): 补充进度状态测试与Task-002记录
 - PR: 待创建
 
 ## Stage Check
 - Stage 1: 已完成（澄清）
 - Stage 2: 已完成（方案与拆分）
-- Stage 3: 进行中（编码与测试）
+- Stage 3: 已完成（实现+lint/test/build 全绿）

--- a/docs/events/DEV-20260226-002-event-log.md
+++ b/docs/events/DEV-20260226-002-event-log.md
@@ -1,0 +1,18 @@
+# DEV-20260226-002 Event Log
+
+## Timeline
+- 2026-02-26: 创建主任务 Issue [#8](https://github.com/gui16789/zpdAcademy/issues/8)
+- 2026-02-26: 创建子任务 Issue [#9](https://github.com/gui16789/zpdAcademy/issues/9) [#10](https://github.com/gui16789/zpdAcademy/issues/10) [#11](https://github.com/gui16789/zpdAcademy/issues/11) [#12](https://github.com/gui16789/zpdAcademy/issues/12)
+- 2026-02-26: 开始分支 `feat/DEV-20260226-002-map-progress` 开发
+
+## Traceability
+- Task: DEV-20260226-002
+- Parent Issue: #8
+- Child Issues: #9 #10 #11 #12
+- Branch: `feat/DEV-20260226-002-map-progress`
+- PR: 待创建
+
+## Stage Check
+- Stage 1: 已完成（澄清）
+- Stage 2: 已完成（方案与拆分）
+- Stage 3: 进行中（编码与测试）

--- a/docs/tasks/DEV-20260226-002-map-progress.md
+++ b/docs/tasks/DEV-20260226-002-map-progress.md
@@ -54,4 +54,8 @@
 ## 流水线记录（GitHub）
 - 主任务 Issue：[#8](https://github.com/gui16789/zpdAcademy/issues/8)
 - 功能分支：`feat/DEV-20260226-002-map-progress`
+- Commit：
+  - `382b1ed`（Sub-1, Sub-2）
+  - `3b0ecbd`（Sub-3）
+  - `f987585`（Sub-4）
 - Event Log：`docs/events/DEV-20260226-002-event-log.md`

--- a/docs/tasks/DEV-20260226-002-map-progress.md
+++ b/docs/tasks/DEV-20260226-002-map-progress.md
@@ -1,0 +1,57 @@
+# DEV-20260226-002 · 地图页进度闭环（Mock）
+
+## Stage 1 澄清结论
+1. 我的理解
+- 在已完成登录闭环基础上，补全 `/map` 页面最小可用学习进度体验。
+- 用户进入地图后可看到单元列表、当前可学习单元、已完成单元与锁定单元状态。
+2. 边界确认
+- 仅做前端 mock，不对接后端。
+- 不实现题目详情页，不实现持久化同步。
+3. 依赖检查
+- 依赖 DEV-20260226-001 已完成的登录态和路由骨架。
+
+## Stage 2 设计与任务拆分
+
+### In Scope
+- 增加地图单元数据模型与常量。
+- 增加学习进度 Store 与状态选择逻辑。
+- 重构 Map 页面为可交互单元网格。
+- 为核心进度逻辑补单元测试。
+
+### Out of Scope
+- 后端进度同步。
+- 课程详情/题目页面。
+- 数据持久化（localStorage/supabase）。
+
+### 子任务（每个 <= 2h）
+1. Sub-1 基建型：单元数据与类型定义（预计 45min）
+- 文件：`src/types/progress.ts`, `src/config/constants.ts`
+- 依赖：无
+- 验收：单元清单和状态枚举可复用。
+- Issue：[#9](https://github.com/gui16789/zpdAcademy/issues/9)
+2. Sub-2 功能型：进度 Store 与状态选择器（预计 60min）
+- 文件：`src/store/progressStore.ts`, `src/features/progress/selectors.ts`
+- 依赖：Sub-1
+- 验收：可计算 completed/unlocked/locked 三种状态。
+- Issue：[#10](https://github.com/gui16789/zpdAcademy/issues/10)
+3. Sub-3 集成型：Map 页面交互重构（预计 90min）
+- 文件：`src/views/Map/MapPage.tsx`
+- 依赖：Sub-2
+- 验收：可触发“开始学习/复习”，完成后自动解锁下一单元。
+- Issue：[#11](https://github.com/gui16789/zpdAcademy/issues/11)
+4. Sub-4 测试型：进度逻辑单元测试（预计 45min）
+- 文件：`src/features/progress/selectors.test.ts`
+- 依赖：Sub-2
+- 验收：状态计算测试覆盖关键路径。
+- Issue：[#12](https://github.com/gui16789/zpdAcademy/issues/12)
+
+## 风险与应对
+1. 风险：后续接后端时状态来源变化。
+- 应对：通过 selector + store 边界隔离 UI 与数据源。
+2. 风险：无持久化导致刷新丢失进度。
+- 应对：在文档中明确为已知 P1 技术债，后续任务偿还。
+
+## 流水线记录（GitHub）
+- 主任务 Issue：[#8](https://github.com/gui16789/zpdAcademy/issues/8)
+- 功能分支：`feat/DEV-20260226-002-map-progress`
+- Event Log：`docs/events/DEV-20260226-002-event-log.md`

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,7 @@
+import type { LearningUnit } from '../types/progress'
+
 export const TASK_ID = 'DEV-20260226-001'
+export const MAP_PROGRESS_TASK_ID = 'DEV-20260226-002'
 
 export const ROUTES = {
   root: '/',
@@ -16,3 +19,30 @@ export const AUTH_CONFIG = {
   passwordMinLength: 6,
   mockLatencyMs: 200,
 } as const
+
+export const LEARNING_UNITS: LearningUnit[] = [
+  {
+    id: 'unit-01',
+    title: 'Unit 01 · 入门',
+    summary: '认识学习路径和目标，完成起步检查。',
+    durationMin: 20,
+  },
+  {
+    id: 'unit-02',
+    title: 'Unit 02 · 基础训练',
+    summary: '完成基础技能训练与首次挑战。',
+    durationMin: 30,
+  },
+  {
+    id: 'unit-03',
+    title: 'Unit 03 · 进阶实践',
+    summary: '进入综合题组，提升稳定性与速度。',
+    durationMin: 35,
+  },
+  {
+    id: 'unit-04',
+    title: 'Unit 04 · 巩固与复盘',
+    summary: '针对薄弱点复盘，完成阶段结业。',
+    durationMin: 25,
+  },
+]

--- a/src/features/progress/selectors.test.ts
+++ b/src/features/progress/selectors.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { getLearningUnitsWithStatus } from './selectors'
+import type { LearningUnit } from '../../types/progress'
+
+const testUnits: LearningUnit[] = [
+  { id: 'u1', title: 'Unit 1', summary: 'S1', durationMin: 10 },
+  { id: 'u2', title: 'Unit 2', summary: 'S2', durationMin: 10 },
+  { id: 'u3', title: 'Unit 3', summary: 'S3', durationMin: 10 },
+]
+
+describe('getLearningUnitsWithStatus', () => {
+  it('marks first unit unlocked when there is no progress', () => {
+    const result = getLearningUnitsWithStatus(testUnits, [], 0)
+
+    expect(result.map((item) => item.status)).toEqual(['unlocked', 'locked', 'locked'])
+  })
+
+  it('marks completed unit and unlocks next one', () => {
+    const result = getLearningUnitsWithStatus(testUnits, ['u1'], 1)
+
+    expect(result.map((item) => item.status)).toEqual(['completed', 'unlocked', 'locked'])
+  })
+
+  it('marks actionable correctly', () => {
+    const result = getLearningUnitsWithStatus(testUnits, ['u1', 'u2'], 2)
+
+    expect(result.map((item) => item.isActionable)).toEqual([true, true, true])
+    expect(result[2]?.status).toBe('unlocked')
+  })
+})

--- a/src/features/progress/selectors.ts
+++ b/src/features/progress/selectors.ts
@@ -1,0 +1,34 @@
+import type { LearningUnit, LearningUnitWithStatus, UnitStatus } from '../../types/progress'
+
+function resolveUnitStatus(
+  unitId: string,
+  unitIndex: number,
+  completedUnitIds: string[],
+  currentUnlockedIndex: number,
+): UnitStatus {
+  if (completedUnitIds.includes(unitId)) {
+    return 'completed'
+  }
+
+  if (unitIndex <= currentUnlockedIndex) {
+    return 'unlocked'
+  }
+
+  return 'locked'
+}
+
+export function getLearningUnitsWithStatus(
+  units: LearningUnit[],
+  completedUnitIds: string[],
+  currentUnlockedIndex: number,
+): LearningUnitWithStatus[] {
+  return units.map((unit, index) => {
+    const status = resolveUnitStatus(unit.id, index, completedUnitIds, currentUnlockedIndex)
+
+    return {
+      ...unit,
+      status,
+      isActionable: status !== 'locked',
+    }
+  })
+}

--- a/src/store/progressStore.ts
+++ b/src/store/progressStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand'
+import { LEARNING_UNITS } from '../config/constants'
+
+interface ProgressStoreState {
+  completedUnitIds: string[]
+  currentUnlockedIndex: number
+  markUnitCompleted: (unitId: string) => void
+  resetProgress: () => void
+}
+
+const INITIAL_UNLOCKED_INDEX = 0
+
+export const useProgressStore = create<ProgressStoreState>((set) => ({
+  completedUnitIds: [],
+  currentUnlockedIndex: INITIAL_UNLOCKED_INDEX,
+  markUnitCompleted: (unitId) =>
+    set((state) => {
+      const completedUnitIds = state.completedUnitIds.includes(unitId)
+        ? state.completedUnitIds
+        : [...state.completedUnitIds, unitId]
+
+      const completedIndex = LEARNING_UNITS.findIndex((unit) => unit.id === unitId)
+      const nextUnlockedIndex =
+        completedIndex >= state.currentUnlockedIndex
+          ? Math.min(completedIndex + 1, LEARNING_UNITS.length - 1)
+          : state.currentUnlockedIndex
+
+      return {
+        completedUnitIds,
+        currentUnlockedIndex: nextUnlockedIndex,
+      }
+    }),
+  resetProgress: () =>
+    set({
+      completedUnitIds: [],
+      currentUnlockedIndex: INITIAL_UNLOCKED_INDEX,
+    }),
+}))

--- a/src/types/progress.ts
+++ b/src/types/progress.ts
@@ -1,0 +1,13 @@
+export type UnitStatus = 'completed' | 'unlocked' | 'locked'
+
+export interface LearningUnit {
+  id: string
+  title: string
+  summary: string
+  durationMin: number
+}
+
+export interface LearningUnitWithStatus extends LearningUnit {
+  status: UnitStatus
+  isActionable: boolean
+}

--- a/src/views/Map/MapPage.tsx
+++ b/src/views/Map/MapPage.tsx
@@ -1,11 +1,24 @@
+import { useState } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
-import { ROUTES, UI_CONFIG } from '../../config/constants'
+import { LEARNING_UNITS, MAP_PROGRESS_TASK_ID, ROUTES, UI_CONFIG } from '../../config/constants'
+import { getLearningUnitsWithStatus } from '../../features/progress/selectors'
+import { useProgressStore } from '../../store/progressStore'
 import { useUserStore } from '../../store/userStore'
+import type { LearningUnitWithStatus } from '../../types/progress'
 
 export function MapPage() {
   const navigate = useNavigate()
   const user = useUserStore((state) => state.user)
   const clearUser = useUserStore((state) => state.clearUser)
+  const completedUnitIds = useProgressStore((state) => state.completedUnitIds)
+  const currentUnlockedIndex = useProgressStore((state) => state.currentUnlockedIndex)
+  const markUnitCompleted = useProgressStore((state) => state.markUnitCompleted)
+  const resetProgress = useProgressStore((state) => state.resetProgress)
+  const [feedback, setFeedback] = useState<string | null>(null)
+
+  const units = getLearningUnitsWithStatus(LEARNING_UNITS, completedUnitIds, currentUnlockedIndex)
+
+  const completedCount = completedUnitIds.length
 
   if (!user) {
     return <Navigate to={ROUTES.login} replace />
@@ -16,22 +29,107 @@ export function MapPage() {
     navigate(ROUTES.login)
   }
 
+  function getButtonLabel(unit: LearningUnitWithStatus): string {
+    if (unit.status === 'completed') {
+      return '复习单元'
+    }
+
+    if (unit.status === 'unlocked') {
+      return '开始学习'
+    }
+
+    return '未解锁'
+  }
+
+  function handleUnitAction(unit: LearningUnitWithStatus) {
+    if (unit.status === 'locked') {
+      return
+    }
+
+    if (unit.status === 'unlocked') {
+      markUnitCompleted(unit.id)
+      setFeedback(`${unit.title} 已完成，下一单元已解锁。`)
+      return
+    }
+
+    setFeedback(`正在复习 ${unit.title}。`)
+  }
+
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col justify-center px-6 py-12">
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col justify-center px-6 py-12">
       <section className="rounded-3xl border border-[color:var(--stroke)] bg-[color:var(--surface)] p-8 shadow-[0_16px_50px_rgba(0,0,0,0.3)] backdrop-blur-sm md:p-10">
-        <p className="text-sm uppercase tracking-[0.28em] text-[color:var(--ink-muted)]">MVP Landing</p>
+        <p className="text-sm uppercase tracking-[0.28em] text-[color:var(--ink-muted)]">MVP Map</p>
         <h1 className="mt-3 text-4xl font-bold text-[color:var(--ink)]">欢迎，{user.username}</h1>
         <p className="mt-3 max-w-2xl text-base text-[color:var(--ink-muted)]">
-          登录闭环已打通。下一阶段将在此页面继续接入课程地图、学习进度和关卡流程。
+          学习进度任务：<span className="font-semibold text-[color:var(--accent)]">{MAP_PROGRESS_TASK_ID}</span>
         </p>
-        <button
-          type="button"
-          onClick={handleLogout}
-          className="mt-8 inline-flex rounded-2xl border border-[color:var(--stroke)] bg-transparent px-6 text-base font-semibold text-[color:var(--ink)] transition hover:border-[color:var(--accent)]"
-          style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
-        >
-          退出登录
-        </button>
+        <p className="mt-3 text-base text-[color:var(--ink-muted)]">
+          进度：{completedCount} / {LEARNING_UNITS.length} 单元已完成
+        </p>
+
+        {feedback ? <p className="mt-4 text-sm text-[color:var(--accent)]">{feedback}</p> : null}
+
+        <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2">
+          {units.map((unit) => (
+            <article
+              key={unit.id}
+              className="rounded-2xl border border-[color:var(--stroke)] bg-[#0a1d3b]/70 p-5"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <h2 className="text-xl font-semibold">{unit.title}</h2>
+                <span
+                  className="rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wider"
+                  style={{
+                    backgroundColor:
+                      unit.status === 'completed'
+                        ? 'rgba(84,242,189,0.16)'
+                        : unit.status === 'unlocked'
+                          ? 'rgba(123,169,255,0.2)'
+                          : 'rgba(173,196,239,0.14)',
+                    color:
+                      unit.status === 'completed'
+                        ? '#54f2bd'
+                        : unit.status === 'unlocked'
+                          ? '#9ab9ff'
+                          : '#adc4ef',
+                  }}
+                >
+                  {unit.status}
+                </span>
+              </div>
+              <p className="mt-2 text-sm text-[color:var(--ink-muted)]">{unit.summary}</p>
+              <p className="mt-2 text-sm text-[color:var(--ink-muted)]">预计 {unit.durationMin} 分钟</p>
+              <button
+                type="button"
+                disabled={!unit.isActionable}
+                onClick={() => handleUnitAction(unit)}
+                className="mt-4 w-full rounded-xl border border-[color:var(--stroke)] px-4 text-base font-semibold transition enabled:hover:border-[color:var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+                style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+              >
+                {getButtonLabel(unit)}
+              </button>
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3 md:flex-row">
+          <button
+            type="button"
+            onClick={resetProgress}
+            className="inline-flex rounded-2xl border border-[color:var(--stroke)] bg-transparent px-6 text-base font-semibold text-[color:var(--ink)] transition hover:border-[color:var(--accent)]"
+            style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+          >
+            重置进度
+          </button>
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="inline-flex rounded-2xl border border-[color:var(--stroke)] bg-transparent px-6 text-base font-semibold text-[color:var(--ink)] transition hover:border-[color:var(--accent)]"
+            style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+          >
+            退出登录
+          </button>
+        </div>
       </section>
     </main>
   )


### PR DESCRIPTION
## 📋 关联需求
- Notion Task: DEV-20260226-002
- Parent Issue: #8
- 依赖 PR: #7（本 PR 基于该分支继续开发）

## 📝 变更说明
- 新增学习单元模型与地图数据常量
- 新增进度状态 store 与 selector
- 重构 Map 页面为单元卡片交互（完成后解锁下一单元）
- 增加进度状态单元测试
- 补充 Task/Event 流水线记录

## ✅ 自检
- [x] npm run lint
- [x] npm run test
- [x] npm run build

## 🔗 Issues
- Refs #8
- Refs #9
- Refs #10
- Refs #11
- Refs #12