### PR TITLE
feat(progress): 持久化学习进度并增加题目页骨架

### DIFF
--- a/docs/events/DEV-20260226-003-event-log.md
+++ b/docs/events/DEV-20260226-003-event-log.md
@@ -4,6 +4,7 @@
 - 2026-02-26: 创建主任务 Issue [#14](https://github.com/gui16789/zpdAcademy/issues/14)
 - 2026-02-26: 创建子任务 Issue [#15](https://github.com/gui16789/zpdAcademy/issues/15) [#16](https://github.com/gui16789/zpdAcademy/issues/16) [#17](https://github.com/gui16789/zpdAcademy/issues/17) [#18](https://github.com/gui16789/zpdAcademy/issues/18)
 - 2026-02-26: 开始分支 `feat/DEV-20260226-003-progress-persistence` 开发
+- 2026-02-26: 提交 PR [#19](https://github.com/gui16789/zpdAcademy/pull/19)
 
 ## Traceability
 - Task: DEV-20260226-003
@@ -13,7 +14,8 @@
 - Commits:
   - `373245e` feat(progress): 增加进度存储服务与持久化
   - `080802c` feat(question): 增加题目页路由骨架并联动地图
-- PR: 待创建
+  - `463d017` test(docs): 增加进度存储测试与Task-003记录
+- PR: #19
 
 ## Stage Check
 - Stage 1: 已完成（澄清）

--- a/docs/events/DEV-20260226-003-event-log.md
+++ b/docs/events/DEV-20260226-003-event-log.md
@@ -1,0 +1,21 @@
+# DEV-20260226-003 Event Log
+
+## Timeline
+- 2026-02-26: 创建主任务 Issue [#14](https://github.com/gui16789/zpdAcademy/issues/14)
+- 2026-02-26: 创建子任务 Issue [#15](https://github.com/gui16789/zpdAcademy/issues/15) [#16](https://github.com/gui16789/zpdAcademy/issues/16) [#17](https://github.com/gui16789/zpdAcademy/issues/17) [#18](https://github.com/gui16789/zpdAcademy/issues/18)
+- 2026-02-26: 开始分支 `feat/DEV-20260226-003-progress-persistence` 开发
+
+## Traceability
+- Task: DEV-20260226-003
+- Parent Issue: #14
+- Child Issues: #15 #16 #17 #18
+- Branch: `feat/DEV-20260226-003-progress-persistence`
+- Commits:
+  - `373245e` feat(progress): 增加进度存储服务与持久化
+  - `080802c` feat(question): 增加题目页路由骨架并联动地图
+- PR: 待创建
+
+## Stage Check
+- Stage 1: 已完成（澄清）
+- Stage 2: 已完成（设计与拆分）
+- Stage 3: 已完成（实现+lint/test/build 全绿）

--- a/docs/tasks/DEV-20260226-003-progress-persistence.md
+++ b/docs/tasks/DEV-20260226-003-progress-persistence.md
@@ -57,4 +57,6 @@
 - Commit：
   - `373245e`（Sub-1, Sub-2）
   - `080802c`（Sub-3）
+  - `463d017`（Sub-4）
+- PR：[#19](https://github.com/gui16789/zpdAcademy/pull/19)
 - Event Log：`docs/events/DEV-20260226-003-event-log.md`

--- a/docs/tasks/DEV-20260226-003-progress-persistence.md
+++ b/docs/tasks/DEV-20260226-003-progress-persistence.md
@@ -1,0 +1,60 @@
+# DEV-20260226-003 · 进度持久化与题目页路由骨架
+
+## Stage 1 澄清结论
+1. 我的理解
+- 在地图进度闭环基础上，补齐刷新不丢进度能力，并引入题目页路由骨架。
+- 地图页只负责导航到学习单元，单元完成动作放到题目页执行。
+2. 边界确认
+- 持久化仅使用 localStorage（前端 mock 阶段）。
+- 题目页只提供骨架与最小交互，不实现真实题库流程。
+3. 依赖检查
+- 依赖 DEV-20260226-002 的进度状态层和地图交互。
+
+## Stage 2 设计与任务拆分
+
+### In Scope
+- 增加进度存储服务（localStorage adapter）。
+- 重构 progress store 以支持读写持久化。
+- 增加 `/question/:unitId` 路由与题目页骨架。
+- 增加存储服务单元测试与回归测试。
+
+### Out of Scope
+- 后端同步、用户多端一致性。
+- 真正题目渲染与判题逻辑。
+- 权限体系与离线冲突处理。
+
+### 子任务（每个 <= 2h）
+1. Sub-1 基建型：进度存储服务（预计 45min）
+- 文件：`src/services/storage/progressStorage.ts`, `src/config/constants.ts`
+- 依赖：无
+- 验收：可安全读写进度快照，异常数据降级默认值。
+- Issue：[#15](https://github.com/gui16789/zpdAcademy/issues/15)
+2. Sub-2 功能型：progress store 持久化改造（预计 60min）
+- 文件：`src/store/progressStore.ts`
+- 依赖：Sub-1
+- 验收：刷新后进度保持，重置后清空存储。
+- Issue：[#16](https://github.com/gui16789/zpdAcademy/issues/16)
+3. Sub-3 集成型：题目页路由骨架与地图联动（预计 90min）
+- 文件：`src/router/AppRouter.tsx`, `src/views/Map/MapPage.tsx`, `src/views/Question/QuestionPage.tsx`
+- 依赖：Sub-2
+- 验收：地图可进入题目页，题目页可完成单元并返回地图。
+- Issue：[#17](https://github.com/gui16789/zpdAcademy/issues/17)
+4. Sub-4 测试型：存储与进度回归测试（预计 45min）
+- 文件：`src/services/storage/progressStorage.test.ts`
+- 依赖：Sub-1
+- 验收：空存储、坏数据、正常读写均有测试覆盖。
+- Issue：[#18](https://github.com/gui16789/zpdAcademy/issues/18)
+
+## 风险与应对
+1. 风险：localStorage 不可用导致状态异常。
+- 应对：存储服务内部兜底 try/catch，失败回退默认快照。
+2. 风险：路由参数无效导致页面错误。
+- 应对：题目页在 unit 不存在时回退 `/map`。
+
+## 流水线记录（GitHub）
+- 主任务 Issue：[#14](https://github.com/gui16789/zpdAcademy/issues/14)
+- 功能分支：`feat/DEV-20260226-003-progress-persistence`
+- Commit：
+  - `373245e`（Sub-1, Sub-2）
+  - `080802c`（Sub-3）
+- Event Log：`docs/events/DEV-20260226-003-event-log.md`

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,12 +2,19 @@ import type { LearningUnit } from '../types/progress'
 
 export const TASK_ID = 'DEV-20260226-001'
 export const MAP_PROGRESS_TASK_ID = 'DEV-20260226-002'
+export const PROGRESS_PERSIST_TASK_ID = 'DEV-20260226-003'
+export const PROGRESS_STORAGE_KEY = 'zpd-academy-progress-v1'
 
 export const ROUTES = {
   root: '/',
   login: '/login',
   map: '/map',
+  question: '/question/:unitId',
 } as const
+
+export function buildQuestionRoute(unitId: string): string {
+  return ROUTES.question.replace(':unitId', unitId)
+}
 
 export const UI_CONFIG = {
   touchTargetMinPx: 44,

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import { ROUTES } from '../config/constants'
 import { LoginPage } from '../views/Login/LoginPage'
 import { MapPage } from '../views/Map/MapPage'
+import { QuestionPage } from '../views/Question/QuestionPage'
 
 export function AppRouter() {
   return (
@@ -10,6 +11,7 @@ export function AppRouter() {
         <Route path={ROUTES.root} element={<Navigate to={ROUTES.login} replace />} />
         <Route path={ROUTES.login} element={<LoginPage />} />
         <Route path={ROUTES.map} element={<MapPage />} />
+        <Route path={ROUTES.question} element={<QuestionPage />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/services/storage/progressStorage.test.ts
+++ b/src/services/storage/progressStorage.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { PROGRESS_STORAGE_KEY } from '../../config/constants'
+import {
+  clearProgressSnapshot,
+  getDefaultProgressSnapshot,
+  loadProgressSnapshot,
+  normalizeProgressSnapshot,
+  saveProgressSnapshot,
+} from './progressStorage'
+
+describe('progressStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('returns default snapshot when storage is empty', () => {
+    expect(loadProgressSnapshot()).toEqual(getDefaultProgressSnapshot())
+  })
+
+  it('saves and loads snapshot from localStorage', () => {
+    const snapshot = {
+      completedUnitIds: ['unit-01', 'unit-02'],
+      currentUnlockedIndex: 2,
+    }
+
+    saveProgressSnapshot(snapshot)
+
+    expect(loadProgressSnapshot()).toEqual(snapshot)
+  })
+
+  it('falls back to default when stored json is invalid', () => {
+    window.localStorage.setItem(PROGRESS_STORAGE_KEY, 'not-json')
+
+    expect(loadProgressSnapshot()).toEqual(getDefaultProgressSnapshot())
+  })
+
+  it('normalizes malformed payloads', () => {
+    const malformed = {
+      completedUnitIds: ['unit-01', 5],
+      currentUnlockedIndex: -2,
+    }
+
+    expect(normalizeProgressSnapshot(malformed)).toEqual({
+      completedUnitIds: [],
+      currentUnlockedIndex: 0,
+    })
+  })
+
+  it('clears persisted snapshot', () => {
+    saveProgressSnapshot({
+      completedUnitIds: ['unit-01'],
+      currentUnlockedIndex: 1,
+    })
+
+    clearProgressSnapshot()
+
+    expect(window.localStorage.getItem(PROGRESS_STORAGE_KEY)).toBeNull()
+  })
+})

--- a/src/services/storage/progressStorage.ts
+++ b/src/services/storage/progressStorage.ts
@@ -1,0 +1,75 @@
+import { PROGRESS_STORAGE_KEY } from '../../config/constants'
+import type { ProgressSnapshot } from '../../types/progress'
+
+const DEFAULT_UNLOCKED_INDEX = 0
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+export function getDefaultProgressSnapshot(): ProgressSnapshot {
+  return {
+    completedUnitIds: [],
+    currentUnlockedIndex: DEFAULT_UNLOCKED_INDEX,
+  }
+}
+
+export function normalizeProgressSnapshot(value: unknown): ProgressSnapshot {
+  if (!value || typeof value !== 'object') {
+    return getDefaultProgressSnapshot()
+  }
+
+  const candidate = value as Partial<ProgressSnapshot>
+  const completedUnitIds = isStringArray(candidate.completedUnitIds) ? candidate.completedUnitIds : []
+  const currentUnlockedIndex =
+    typeof candidate.currentUnlockedIndex === 'number' && candidate.currentUnlockedIndex >= 0
+      ? Math.floor(candidate.currentUnlockedIndex)
+      : DEFAULT_UNLOCKED_INDEX
+
+  return {
+    completedUnitIds,
+    currentUnlockedIndex,
+  }
+}
+
+export function loadProgressSnapshot(): ProgressSnapshot {
+  if (typeof window === 'undefined') {
+    return getDefaultProgressSnapshot()
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(PROGRESS_STORAGE_KEY)
+
+    if (!rawValue) {
+      return getDefaultProgressSnapshot()
+    }
+
+    return normalizeProgressSnapshot(JSON.parse(rawValue))
+  } catch {
+    return getDefaultProgressSnapshot()
+  }
+}
+
+export function saveProgressSnapshot(snapshot: ProgressSnapshot): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(PROGRESS_STORAGE_KEY, JSON.stringify(snapshot))
+  } catch {
+    // keep runtime resilient when storage is blocked
+  }
+}
+
+export function clearProgressSnapshot(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.removeItem(PROGRESS_STORAGE_KEY)
+  } catch {
+    // ignore storage cleanup errors
+  }
+}

--- a/src/store/progressStore.ts
+++ b/src/store/progressStore.ts
@@ -1,5 +1,11 @@
 import { create } from 'zustand'
 import { LEARNING_UNITS } from '../config/constants'
+import {
+  clearProgressSnapshot,
+  loadProgressSnapshot,
+  saveProgressSnapshot,
+} from '../services/storage/progressStorage'
+import type { ProgressSnapshot } from '../types/progress'
 
 interface ProgressStoreState {
   completedUnitIds: string[]
@@ -9,10 +15,28 @@ interface ProgressStoreState {
 }
 
 const INITIAL_UNLOCKED_INDEX = 0
+const MAX_UNLOCKED_INDEX = LEARNING_UNITS.length - 1
+const persistedSnapshot = loadProgressSnapshot()
+const unitIdSet = new Set(LEARNING_UNITS.map((unit) => unit.id))
+
+function clampUnlockedIndex(index: number): number {
+  if (index < INITIAL_UNLOCKED_INDEX) {
+    return INITIAL_UNLOCKED_INDEX
+  }
+
+  return Math.min(index, MAX_UNLOCKED_INDEX)
+}
+
+function persistSnapshot(snapshot: ProgressSnapshot): void {
+  saveProgressSnapshot({
+    completedUnitIds: snapshot.completedUnitIds,
+    currentUnlockedIndex: clampUnlockedIndex(snapshot.currentUnlockedIndex),
+  })
+}
 
 export const useProgressStore = create<ProgressStoreState>((set) => ({
-  completedUnitIds: [],
-  currentUnlockedIndex: INITIAL_UNLOCKED_INDEX,
+  completedUnitIds: persistedSnapshot.completedUnitIds.filter((unitId) => unitIdSet.has(unitId)),
+  currentUnlockedIndex: clampUnlockedIndex(persistedSnapshot.currentUnlockedIndex),
   markUnitCompleted: (unitId) =>
     set((state) => {
       const completedUnitIds = state.completedUnitIds.includes(unitId)
@@ -25,14 +49,20 @@ export const useProgressStore = create<ProgressStoreState>((set) => ({
           ? Math.min(completedIndex + 1, LEARNING_UNITS.length - 1)
           : state.currentUnlockedIndex
 
-      return {
+      const nextSnapshot = {
         completedUnitIds,
         currentUnlockedIndex: nextUnlockedIndex,
       }
+
+      persistSnapshot(nextSnapshot)
+
+      return nextSnapshot
     }),
-  resetProgress: () =>
+  resetProgress: () => {
+    clearProgressSnapshot()
     set({
       completedUnitIds: [],
       currentUnlockedIndex: INITIAL_UNLOCKED_INDEX,
-    }),
+    })
+  },
 }))

--- a/src/types/progress.ts
+++ b/src/types/progress.ts
@@ -11,3 +11,8 @@ export interface LearningUnitWithStatus extends LearningUnit {
   status: UnitStatus
   isActionable: boolean
 }
+
+export interface ProgressSnapshot {
+  completedUnitIds: string[]
+  currentUnlockedIndex: number
+}

--- a/src/views/Map/MapPage.tsx
+++ b/src/views/Map/MapPage.tsx
@@ -1,6 +1,13 @@
 import { useState } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
-import { LEARNING_UNITS, MAP_PROGRESS_TASK_ID, ROUTES, UI_CONFIG } from '../../config/constants'
+import {
+  LEARNING_UNITS,
+  MAP_PROGRESS_TASK_ID,
+  PROGRESS_PERSIST_TASK_ID,
+  ROUTES,
+  UI_CONFIG,
+  buildQuestionRoute,
+} from '../../config/constants'
 import { getLearningUnitsWithStatus } from '../../features/progress/selectors'
 import { useProgressStore } from '../../store/progressStore'
 import { useUserStore } from '../../store/userStore'
@@ -12,7 +19,6 @@ export function MapPage() {
   const clearUser = useUserStore((state) => state.clearUser)
   const completedUnitIds = useProgressStore((state) => state.completedUnitIds)
   const currentUnlockedIndex = useProgressStore((state) => state.currentUnlockedIndex)
-  const markUnitCompleted = useProgressStore((state) => state.markUnitCompleted)
   const resetProgress = useProgressStore((state) => state.resetProgress)
   const [feedback, setFeedback] = useState<string | null>(null)
 
@@ -35,7 +41,7 @@ export function MapPage() {
     }
 
     if (unit.status === 'unlocked') {
-      return '开始学习'
+      return '进入单元'
     }
 
     return '未解锁'
@@ -43,16 +49,11 @@ export function MapPage() {
 
   function handleUnitAction(unit: LearningUnitWithStatus) {
     if (unit.status === 'locked') {
+      setFeedback(`${unit.title} 尚未解锁。`)
       return
     }
 
-    if (unit.status === 'unlocked') {
-      markUnitCompleted(unit.id)
-      setFeedback(`${unit.title} 已完成，下一单元已解锁。`)
-      return
-    }
-
-    setFeedback(`正在复习 ${unit.title}。`)
+    navigate(buildQuestionRoute(unit.id))
   }
 
   return (
@@ -62,6 +63,12 @@ export function MapPage() {
         <h1 className="mt-3 text-4xl font-bold text-[color:var(--ink)]">欢迎，{user.username}</h1>
         <p className="mt-3 max-w-2xl text-base text-[color:var(--ink-muted)]">
           学习进度任务：<span className="font-semibold text-[color:var(--accent)]">{MAP_PROGRESS_TASK_ID}</span>
+        </p>
+        <p className="mt-1 max-w-2xl text-base text-[color:var(--ink-muted)]">
+          持久化任务：
+          <span className="ml-1 font-semibold text-[color:var(--accent)]">
+            {PROGRESS_PERSIST_TASK_ID}
+          </span>
         </p>
         <p className="mt-3 text-base text-[color:var(--ink-muted)]">
           进度：{completedCount} / {LEARNING_UNITS.length} 单元已完成

--- a/src/views/Question/QuestionPage.tsx
+++ b/src/views/Question/QuestionPage.tsx
@@ -1,0 +1,66 @@
+import { Navigate, useNavigate, useParams } from 'react-router-dom'
+import { LEARNING_UNITS, PROGRESS_PERSIST_TASK_ID, ROUTES, UI_CONFIG } from '../../config/constants'
+import { useProgressStore } from '../../store/progressStore'
+import { useUserStore } from '../../store/userStore'
+
+export function QuestionPage() {
+  const navigate = useNavigate()
+  const { unitId } = useParams()
+  const user = useUserStore((state) => state.user)
+  const markUnitCompleted = useProgressStore((state) => state.markUnitCompleted)
+  const unit = LEARNING_UNITS.find((item) => item.id === unitId)
+
+  if (!user) {
+    return <Navigate to={ROUTES.login} replace />
+  }
+
+  if (!unit) {
+    return <Navigate to={ROUTES.map} replace />
+  }
+
+  const activeUnit = unit
+
+  function handleCompleteAndBack() {
+    markUnitCompleted(activeUnit.id)
+    navigate(ROUTES.map)
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col justify-center px-6 py-12">
+      <section className="rounded-3xl border border-[color:var(--stroke)] bg-[color:var(--surface)] p-8 shadow-[0_16px_50px_rgba(0,0,0,0.3)] backdrop-blur-sm md:p-10">
+        <p className="text-sm uppercase tracking-[0.28em] text-[color:var(--ink-muted)]">MVP Question</p>
+        <h1 className="mt-3 text-3xl font-bold text-[color:var(--ink)]">{activeUnit.title}</h1>
+        <p className="mt-2 text-base text-[color:var(--ink-muted)]">
+          题目页骨架任务：
+          <span className="ml-1 font-semibold text-[color:var(--accent)]">{PROGRESS_PERSIST_TASK_ID}</span>
+        </p>
+        <p className="mt-4 text-base text-[color:var(--ink-muted)]">{activeUnit.summary}</p>
+
+        <div className="mt-6 rounded-2xl border border-[color:var(--stroke)] bg-[#0a1d3b]/70 p-5">
+          <p className="text-sm text-[color:var(--ink-muted)]">
+            这里预留真实题目流（题干、选项、提交、反馈）。当前 MVP 只验证路由与进度闭环。
+          </p>
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3 md:flex-row">
+          <button
+            type="button"
+            onClick={handleCompleteAndBack}
+            className="inline-flex rounded-2xl bg-[color:var(--accent)] px-6 text-base font-semibold text-[#022125] transition hover:brightness-110"
+            style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+          >
+            完成当前单元并返回地图
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate(ROUTES.map)}
+            className="inline-flex rounded-2xl border border-[color:var(--stroke)] bg-transparent px-6 text-base font-semibold text-[color:var(--ink)] transition hover:border-[color:var(--accent)]"
+            style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+          >
+            返回地图
+          </button>
+        </div>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## 📋 关联需求
- Notion Task: DEV-20260226-003
- Parent Issue: #14

## 📝 变更说明
- 新增 progress storage service（localStorage adapter）
- 改造 progress store，实现刷新保持进度与重置清理
- 新增 `/question/:unitId` 路由与题目页骨架
- Map 页面改为进入题目页，题目页完成后返回地图
- 补充存储层测试与任务/事件记录

## ✅ 自检
- [x] npm run lint
- [x] npm run test
- [x] npm run build

## 🔗 关闭 Issues
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18