### PR TITLE
feat(question): 实现题目页最小答题闭环

### DIFF
--- a/docs/events/DEV-20260226-004-event-log.md
+++ b/docs/events/DEV-20260226-004-event-log.md
@@ -10,9 +10,13 @@
 - Parent Issue: #20
 - Child Issues: #21 #22 #23 #24
 - Branch: `feat/DEV-20260226-004-question-mvp`
+- Commits:
+  - `afaf473` feat(question): 增加题目模型与判题服务
+  - `0e357a6` feat(question): 实现题目页答题交互与达标流程
+  - `8e07bb6` test(docs): 增加判题测试与Task-004记录
 - PR: 待创建
 
 ## Stage Check
 - Stage 1: 已完成（澄清）
 - Stage 2: 已完成（设计与拆分）
-- Stage 3: 进行中（编码与测试）
+- Stage 3: 已完成（实现+lint/test/build 全绿）

--- a/docs/events/DEV-20260226-004-event-log.md
+++ b/docs/events/DEV-20260226-004-event-log.md
@@ -1,0 +1,18 @@
+# DEV-20260226-004 Event Log
+
+## Timeline
+- 2026-02-26: 创建主任务 Issue [#20](https://github.com/gui16789/zpdAcademy/issues/20)
+- 2026-02-26: 创建子任务 Issue [#21](https://github.com/gui16789/zpdAcademy/issues/21) [#22](https://github.com/gui16789/zpdAcademy/issues/22) [#23](https://github.com/gui16789/zpdAcademy/issues/23) [#24](https://github.com/gui16789/zpdAcademy/issues/24)
+- 2026-02-26: 开始分支 `feat/DEV-20260226-004-question-mvp` 开发
+
+## Traceability
+- Task: DEV-20260226-004
+- Parent Issue: #20
+- Child Issues: #21 #22 #23 #24
+- Branch: `feat/DEV-20260226-004-question-mvp`
+- PR: 待创建
+
+## Stage Check
+- Stage 1: 已完成（澄清）
+- Stage 2: 已完成（设计与拆分）
+- Stage 3: 进行中（编码与测试）

--- a/docs/events/DEV-20260226-004-event-log.md
+++ b/docs/events/DEV-20260226-004-event-log.md
@@ -4,6 +4,7 @@
 - 2026-02-26: 创建主任务 Issue [#20](https://github.com/gui16789/zpdAcademy/issues/20)
 - 2026-02-26: 创建子任务 Issue [#21](https://github.com/gui16789/zpdAcademy/issues/21) [#22](https://github.com/gui16789/zpdAcademy/issues/22) [#23](https://github.com/gui16789/zpdAcademy/issues/23) [#24](https://github.com/gui16789/zpdAcademy/issues/24)
 - 2026-02-26: 开始分支 `feat/DEV-20260226-004-question-mvp` 开发
+- 2026-02-26: 提交 PR [#25](https://github.com/gui16789/zpdAcademy/pull/25)
 
 ## Traceability
 - Task: DEV-20260226-004
@@ -14,7 +15,8 @@
   - `afaf473` feat(question): 增加题目模型与判题服务
   - `0e357a6` feat(question): 实现题目页答题交互与达标流程
   - `8e07bb6` test(docs): 增加判题测试与Task-004记录
-- PR: 待创建
+  - `3036bf0` docs(event): 回写Task-004提交链路
+- PR: #25
 
 ## Stage Check
 - Stage 1: 已完成（澄清）

--- a/docs/tasks/DEV-20260226-004-question-mvp.md
+++ b/docs/tasks/DEV-20260226-004-question-mvp.md
@@ -59,4 +59,6 @@
   - `afaf473`（Sub-1, Sub-2）
   - `0e357a6`（Sub-3）
   - `8e07bb6`（Sub-4）
+  - `3036bf0`（traceability）
+- PR：[#25](https://github.com/gui16789/zpdAcademy/pull/25)
 - Event Log：`docs/events/DEV-20260226-004-event-log.md`

--- a/docs/tasks/DEV-20260226-004-question-mvp.md
+++ b/docs/tasks/DEV-20260226-004-question-mvp.md
@@ -55,4 +55,8 @@
 ## 流水线记录（GitHub）
 - 主任务 Issue：[#20](https://github.com/gui16789/zpdAcademy/issues/20)
 - 功能分支：`feat/DEV-20260226-004-question-mvp`
+- Commit：
+  - `afaf473`（Sub-1, Sub-2）
+  - `0e357a6`（Sub-3）
+  - `8e07bb6`（Sub-4）
 - Event Log：`docs/events/DEV-20260226-004-event-log.md`

--- a/docs/tasks/DEV-20260226-004-question-mvp.md
+++ b/docs/tasks/DEV-20260226-004-question-mvp.md
@@ -1,0 +1,58 @@
+# DEV-20260226-004 · 题目页答题闭环（Mock）
+
+## Stage 1 澄清结论
+1. 我的理解
+- 在已有题目页骨架基础上，实现最小答题流程：加载题目、选择答案、提交判分、达标后完成单元。
+- 本轮只覆盖单选题，不做多题型扩展。
+2. 边界确认
+- 题目数据使用本地 mock。
+- 不接真实后端与题库管理。
+- 不做排行榜、历史错题、动画效果优化。
+3. 依赖检查
+- 依赖 DEV-20260226-003 的题目页路由与进度持久化能力。
+
+## Stage 2 设计与任务拆分
+
+### In Scope
+- 增加题目数据模型和 mock 题库。
+- 增加判题服务（计分和达标判定）。
+- 重构题目页为可答题流程。
+- 为判题核心逻辑增加单元测试。
+
+### Out of Scope
+- 后端题库同步。
+- 多题型（填空/判断/主观题）。
+- 题目分页与防作弊。
+
+### 子任务（每个 <= 2h）
+1. Sub-1 基建型：题目模型与 mock 题库（预计 45min）
+- 文件：`src/types/question.ts`, `src/data/questionBank.ts`, `src/config/constants.ts`
+- 依赖：无
+- 验收：每个 unit 可取到题目集合。
+- Issue：[#21](https://github.com/gui16789/zpdAcademy/issues/21)
+2. Sub-2 功能型：判题服务与得分规则（预计 60min）
+- 文件：`src/services/question/questionService.ts`
+- 依赖：Sub-1
+- 验收：可输出答题结果、正确数、得分、是否达标。
+- Issue：[#22](https://github.com/gui16789/zpdAcademy/issues/22)
+3. Sub-3 集成型：题目页答题交互（预计 90min）
+- 文件：`src/views/Question/QuestionPage.tsx`
+- 依赖：Sub-2
+- 验收：可作答并提交；达标后完成单元并回地图；未达标可重试。
+- Issue：[#23](https://github.com/gui16789/zpdAcademy/issues/23)
+4. Sub-4 测试型：判题逻辑测试（预计 45min）
+- 文件：`src/services/question/questionService.test.ts`
+- 依赖：Sub-2
+- 验收：覆盖满分、部分正确、未达标三个场景。
+- Issue：[#24](https://github.com/gui16789/zpdAcademy/issues/24)
+
+## 风险与应对
+1. 风险：提交前未答完导致状态混乱。
+- 应对：提交按钮只在全部题目已选答案时可用。
+2. 风险：未来多题型扩展时逻辑耦合。
+- 应对：判题逻辑独立在 service，页面只消费结果。
+
+## 流水线记录（GitHub）
+- 主任务 Issue：[#20](https://github.com/gui16789/zpdAcademy/issues/20)
+- 功能分支：`feat/DEV-20260226-004-question-mvp`
+- Event Log：`docs/events/DEV-20260226-004-event-log.md`

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,6 +3,7 @@ import type { LearningUnit } from '../types/progress'
 export const TASK_ID = 'DEV-20260226-001'
 export const MAP_PROGRESS_TASK_ID = 'DEV-20260226-002'
 export const PROGRESS_PERSIST_TASK_ID = 'DEV-20260226-003'
+export const QUESTION_MVP_TASK_ID = 'DEV-20260226-004'
 export const PROGRESS_STORAGE_KEY = 'zpd-academy-progress-v1'
 
 export const ROUTES = {
@@ -25,6 +26,10 @@ export const AUTH_CONFIG = {
   usernameMinLength: 2,
   passwordMinLength: 6,
   mockLatencyMs: 200,
+} as const
+
+export const QUESTION_CONFIG = {
+  passScore: 70,
 } as const
 
 export const LEARNING_UNITS: LearningUnit[] = [

--- a/src/data/questionBank.ts
+++ b/src/data/questionBank.ts
@@ -1,0 +1,92 @@
+import type { SingleChoiceQuestion } from '../types/question'
+
+export const QUESTION_BANK: SingleChoiceQuestion[] = [
+  {
+    id: 'q-0101',
+    unitId: 'unit-01',
+    prompt: 'React 中用于在组件内保存状态的 Hook 是哪个？',
+    options: [
+      { id: 'a', label: 'useState' },
+      { id: 'b', label: 'useFetch' },
+      { id: 'c', label: 'useBuild' },
+    ],
+    correctOptionId: 'a',
+  },
+  {
+    id: 'q-0102',
+    unitId: 'unit-01',
+    prompt: 'TypeScript strict 模式的主要价值是什么？',
+    options: [
+      { id: 'a', label: '减少编译速度' },
+      { id: 'b', label: '提前暴露类型错误' },
+      { id: 'c', label: '自动生成 UI' },
+    ],
+    correctOptionId: 'b',
+  },
+  {
+    id: 'q-0201',
+    unitId: 'unit-02',
+    prompt: 'Zustand 中创建 store 的常用函数是？',
+    options: [
+      { id: 'a', label: 'create' },
+      { id: 'b', label: 'compose' },
+      { id: 'c', label: 'memo' },
+    ],
+    correctOptionId: 'a',
+  },
+  {
+    id: 'q-0202',
+    unitId: 'unit-02',
+    prompt: 'React Router v6 中声明路由的组件是？',
+    options: [
+      { id: 'a', label: 'Switch' },
+      { id: 'b', label: 'Routes' },
+      { id: 'c', label: 'Navigator' },
+    ],
+    correctOptionId: 'b',
+  },
+  {
+    id: 'q-0301',
+    unitId: 'unit-03',
+    prompt: '下列哪项最符合“单一职责原则”？',
+    options: [
+      { id: 'a', label: '一个模块只做一件事' },
+      { id: 'b', label: '一个函数写满所有逻辑' },
+      { id: 'c', label: '所有状态放到全局变量' },
+    ],
+    correctOptionId: 'a',
+  },
+  {
+    id: 'q-0302',
+    unitId: 'unit-03',
+    prompt: '前端常量集中管理的主要收益是？',
+    options: [
+      { id: 'a', label: '提高魔法数字数量' },
+      { id: 'b', label: '统一配置并降低维护成本' },
+      { id: 'c', label: '绕过类型检查' },
+    ],
+    correctOptionId: 'b',
+  },
+  {
+    id: 'q-0401',
+    unitId: 'unit-04',
+    prompt: '以下哪项属于有效的 PR 自检项？',
+    options: [
+      { id: 'a', label: '不跑测试直接提交' },
+      { id: 'b', label: '确认 lint/test/build 全通过' },
+      { id: 'c', label: '删除所有类型定义' },
+    ],
+    correctOptionId: 'b',
+  },
+  {
+    id: 'q-0402',
+    unitId: 'unit-04',
+    prompt: '当任务范围外改动不可避免时，正确做法是？',
+    options: [
+      { id: 'a', label: '直接改完再说' },
+      { id: 'b', label: '停止并回报，等待范围确认' },
+      { id: 'c', label: '先合并到主分支' },
+    ],
+    correctOptionId: 'b',
+  },
+]

--- a/src/services/question/questionService.test.ts
+++ b/src/services/question/questionService.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { questionService } from './questionService'
+
+describe('questionService', () => {
+  it('returns questions for target unit', () => {
+    const questions = questionService.getQuestionsByUnit('unit-01')
+
+    expect(questions.length).toBeGreaterThan(0)
+    expect(questions.every((question) => question.unitId === 'unit-01')).toBe(true)
+  })
+
+  it('evaluates full correct answers as passed', () => {
+    const questions = questionService.getQuestionsByUnit('unit-01')
+    const submissions = questions.map((question) => ({
+      questionId: question.id,
+      selectedOptionId: question.correctOptionId,
+    }))
+
+    const result = questionService.evaluateQuestions(questions, submissions)
+
+    expect(result.correctCount).toBe(questions.length)
+    expect(result.score).toBe(100)
+    expect(result.isPassed).toBe(true)
+  })
+
+  it('evaluates partial correct answers by score threshold', () => {
+    const questions = questionService.getQuestionsByUnit('unit-02')
+    const submissions = [
+      {
+        questionId: questions[0]?.id ?? '',
+        selectedOptionId: questions[0]?.correctOptionId ?? '',
+      },
+      {
+        questionId: questions[1]?.id ?? '',
+        selectedOptionId: 'invalid',
+      },
+    ]
+
+    const result = questionService.evaluateQuestions(questions, submissions)
+
+    expect(result.correctCount).toBe(1)
+    expect(result.score).toBe(50)
+    expect(result.isPassed).toBe(false)
+  })
+})

--- a/src/services/question/questionService.ts
+++ b/src/services/question/questionService.ts
@@ -1,0 +1,56 @@
+import { QUESTION_BANK } from '../../data/questionBank'
+import { QUESTION_CONFIG } from '../../config/constants'
+import type {
+  QuestionEvaluation,
+  QuestionSubmission,
+  SingleChoiceQuestion,
+} from '../../types/question'
+
+export interface IQuestionService {
+  getQuestionsByUnit(unitId: string): SingleChoiceQuestion[]
+  evaluateQuestions(
+    questions: SingleChoiceQuestion[],
+    submissions: QuestionSubmission[],
+  ): QuestionEvaluation
+}
+
+class QuestionService implements IQuestionService {
+  public getQuestionsByUnit(unitId: string): SingleChoiceQuestion[] {
+    return QUESTION_BANK.filter((question) => question.unitId === unitId)
+  }
+
+  public evaluateQuestions(
+    questions: SingleChoiceQuestion[],
+    submissions: QuestionSubmission[],
+  ): QuestionEvaluation {
+    const submissionMap = new Map(submissions.map((item) => [item.questionId, item.selectedOptionId]))
+
+    const results = questions.map((question) => {
+      const selectedOptionId = submissionMap.get(question.id) ?? null
+      const isCorrect = selectedOptionId === question.correctOptionId
+
+      return {
+        questionId: question.id,
+        selectedOptionId,
+        correctOptionId: question.correctOptionId,
+        isCorrect,
+      }
+    })
+
+    const correctCount = results.filter((result) => result.isCorrect).length
+    const totalQuestions = questions.length
+    const score = totalQuestions === 0 ? 0 : Math.round((correctCount / totalQuestions) * 100)
+    const passScore = QUESTION_CONFIG.passScore
+
+    return {
+      totalQuestions,
+      correctCount,
+      score,
+      passScore,
+      isPassed: score >= passScore,
+      results,
+    }
+  }
+}
+
+export const questionService: IQuestionService = new QuestionService()

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -1,0 +1,33 @@
+export interface QuestionOption {
+  id: string
+  label: string
+}
+
+export interface SingleChoiceQuestion {
+  id: string
+  unitId: string
+  prompt: string
+  options: QuestionOption[]
+  correctOptionId: string
+}
+
+export interface QuestionSubmission {
+  questionId: string
+  selectedOptionId: string
+}
+
+export interface QuestionResultItem {
+  questionId: string
+  selectedOptionId: string | null
+  correctOptionId: string
+  isCorrect: boolean
+}
+
+export interface QuestionEvaluation {
+  totalQuestions: number
+  correctCount: number
+  score: number
+  passScore: number
+  isPassed: boolean
+  results: QuestionResultItem[]
+}

--- a/src/views/Question/QuestionPage.tsx
+++ b/src/views/Question/QuestionPage.tsx
@@ -1,13 +1,18 @@
+import { useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router-dom'
-import { LEARNING_UNITS, PROGRESS_PERSIST_TASK_ID, ROUTES, UI_CONFIG } from '../../config/constants'
+import { LEARNING_UNITS, QUESTION_MVP_TASK_ID, ROUTES, UI_CONFIG } from '../../config/constants'
+import { questionService } from '../../services/question/questionService'
 import { useProgressStore } from '../../store/progressStore'
 import { useUserStore } from '../../store/userStore'
+import type { QuestionEvaluation } from '../../types/question'
 
 export function QuestionPage() {
   const navigate = useNavigate()
   const { unitId } = useParams()
   const user = useUserStore((state) => state.user)
   const markUnitCompleted = useProgressStore((state) => state.markUnitCompleted)
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [evaluation, setEvaluation] = useState<QuestionEvaluation | null>(null)
   const unit = LEARNING_UNITS.find((item) => item.id === unitId)
 
   if (!user) {
@@ -19,6 +24,30 @@ export function QuestionPage() {
   }
 
   const activeUnit = unit
+  const questions = questionService.getQuestionsByUnit(activeUnit.id)
+  const allAnswered =
+    questions.length > 0 && questions.every((question) => typeof answers[question.id] === 'string')
+
+  function handleSelectAnswer(questionId: string, optionId: string) {
+    setEvaluation(null)
+    setAnswers((prev) => ({
+      ...prev,
+      [questionId]: optionId,
+    }))
+  }
+
+  function handleSubmitAnswers() {
+    if (!allAnswered) {
+      return
+    }
+
+    const submissions = questions.map((question) => ({
+      questionId: question.id,
+      selectedOptionId: answers[question.id] ?? '',
+    }))
+
+    setEvaluation(questionService.evaluateQuestions(questions, submissions))
+  }
 
   function handleCompleteAndBack() {
     markUnitCompleted(activeUnit.id)
@@ -31,26 +60,123 @@ export function QuestionPage() {
         <p className="text-sm uppercase tracking-[0.28em] text-[color:var(--ink-muted)]">MVP Question</p>
         <h1 className="mt-3 text-3xl font-bold text-[color:var(--ink)]">{activeUnit.title}</h1>
         <p className="mt-2 text-base text-[color:var(--ink-muted)]">
-          题目页骨架任务：
-          <span className="ml-1 font-semibold text-[color:var(--accent)]">{PROGRESS_PERSIST_TASK_ID}</span>
+          题目页答题任务：
+          <span className="ml-1 font-semibold text-[color:var(--accent)]">{QUESTION_MVP_TASK_ID}</span>
         </p>
         <p className="mt-4 text-base text-[color:var(--ink-muted)]">{activeUnit.summary}</p>
 
-        <div className="mt-6 rounded-2xl border border-[color:var(--stroke)] bg-[#0a1d3b]/70 p-5">
-          <p className="text-sm text-[color:var(--ink-muted)]">
-            这里预留真实题目流（题干、选项、提交、反馈）。当前 MVP 只验证路由与进度闭环。
-          </p>
-        </div>
+        {questions.length === 0 ? (
+          <div className="mt-6 rounded-2xl border border-[color:var(--stroke)] bg-[#0a1d3b]/70 p-5">
+            <p className="text-sm text-[color:var(--ink-muted)]">该单元暂无题目，请返回地图。</p>
+          </div>
+        ) : (
+          <div className="mt-6 space-y-4">
+            {questions.map((question, index) => {
+              const questionResult = evaluation?.results.find((item) => item.questionId === question.id)
+
+              return (
+                <article
+                  key={question.id}
+                  className="rounded-2xl border border-[color:var(--stroke)] bg-[#0a1d3b]/70 p-5"
+                >
+                  <h2 className="text-base font-semibold">
+                    {index + 1}. {question.prompt}
+                  </h2>
+                  <div className="mt-3 grid gap-2">
+                    {question.options.map((option) => {
+                      const isSelected = answers[question.id] === option.id
+                      const shouldHighlightCorrect =
+                        Boolean(evaluation) && option.id === question.correctOptionId
+                      const shouldHighlightWrongSelected =
+                        Boolean(evaluation) && isSelected && option.id !== question.correctOptionId
+
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() => handleSelectAnswer(question.id, option.id)}
+                          className="rounded-xl border px-4 text-left text-sm transition"
+                          style={{
+                            minHeight: UI_CONFIG.touchTargetMinPx,
+                            borderColor: shouldHighlightCorrect
+                              ? '#54f2bd'
+                              : shouldHighlightWrongSelected
+                                ? '#ff7f9d'
+                                : isSelected
+                                  ? '#9ab9ff'
+                                  : 'var(--stroke)',
+                            backgroundColor:
+                              shouldHighlightCorrect || shouldHighlightWrongSelected
+                                ? 'rgba(255,255,255,0.04)'
+                                : 'transparent',
+                          }}
+                          disabled={Boolean(evaluation)}
+                        >
+                          {option.label}
+                        </button>
+                      )
+                    })}
+                  </div>
+                  {evaluation ? (
+                    <p
+                      className="mt-3 text-xs"
+                      style={{ color: questionResult?.isCorrect ? '#54f2bd' : '#ff7f9d' }}
+                    >
+                      {questionResult?.isCorrect ? '回答正确' : '回答错误'}
+                    </p>
+                  ) : null}
+                </article>
+              )
+            })}
+          </div>
+        )}
+
+        {evaluation ? (
+          <div className="mt-6 rounded-2xl border border-[color:var(--stroke)] bg-[#0a1d3b]/70 p-5">
+            <p className="text-base font-semibold">
+              得分：{evaluation.score}（{evaluation.correctCount}/{evaluation.totalQuestions}）
+            </p>
+            <p
+              className="mt-2 text-sm"
+              style={{ color: evaluation.isPassed ? '#54f2bd' : '#ff7f9d' }}
+            >
+              {evaluation.isPassed
+                ? `已达标（>= ${evaluation.passScore}），可完成单元。`
+                : `未达标（需 >= ${evaluation.passScore}），请重试。`}
+            </p>
+          </div>
+        ) : null}
 
         <div className="mt-8 flex flex-col gap-3 md:flex-row">
-          <button
-            type="button"
-            onClick={handleCompleteAndBack}
-            className="inline-flex rounded-2xl bg-[color:var(--accent)] px-6 text-base font-semibold text-[#022125] transition hover:brightness-110"
-            style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
-          >
-            完成当前单元并返回地图
-          </button>
+          {!evaluation ? (
+            <button
+              type="button"
+              onClick={handleSubmitAnswers}
+              disabled={!allAnswered || questions.length === 0}
+              className="inline-flex rounded-2xl bg-[color:var(--accent)] px-6 text-base font-semibold text-[#022125] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+              style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+            >
+              提交答案
+            </button>
+          ) : evaluation.isPassed ? (
+            <button
+              type="button"
+              onClick={handleCompleteAndBack}
+              className="inline-flex rounded-2xl bg-[color:var(--accent)] px-6 text-base font-semibold text-[#022125] transition hover:brightness-110"
+              style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+            >
+              完成当前单元并返回地图
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEvaluation(null)}
+              className="inline-flex rounded-2xl bg-[color:var(--accent)] px-6 text-base font-semibold text-[#022125] transition hover:brightness-110"
+              style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+            >
+              继续重试
+            </button>
+          )}
           <button
             type="button"
             onClick={() => navigate(ROUTES.map)}


### PR DESCRIPTION
## 📋 关联需求
- Notion Task: DEV-20260226-004
- Parent Issue: #20

## 📝 变更说明
- 新增题目模型与 mock 题库
- 新增判题服务（正确数、得分、达标判定）
- 重构题目页为完整答题流（选择、提交、反馈、重试、达标完成）
- 增加判题单元测试
- 同步任务与事件记录

## ✅ 自检
- [x] npm run lint
- [x] npm run test
- [x] npm run build

## 🔗 关闭 Issues
Closes #20
Closes #21
Closes #22
Closes #23
Closes #24