### PR TITLE
feat(progress): 记录并展示单元成绩摘要

### DIFF
--- a/docs/events/DEV-20260226-005-event-log.md
+++ b/docs/events/DEV-20260226-005-event-log.md
@@ -10,9 +10,13 @@
 - Parent Issue: #26
 - Child Issues: #27 #28 #29 #30
 - Branch: `feat/DEV-20260226-005-score-history`
+- Commits:
+  - `bbd1e6a` feat(progress): 增加单元成绩记录与快照兼容
+  - `546029b` feat(map): 展示单元成绩并联动答题结果
+  - `d622fe7` test(docs): 补充成绩持久化测试与Task-005记录
 - PR: 待创建
 
 ## Stage Check
 - Stage 1: 已完成（澄清）
 - Stage 2: 已完成（设计与拆分）
-- Stage 3: 进行中（编码与测试）
+- Stage 3: 已完成（实现+lint/test/build 全绿）

--- a/docs/events/DEV-20260226-005-event-log.md
+++ b/docs/events/DEV-20260226-005-event-log.md
@@ -1,0 +1,18 @@
+# DEV-20260226-005 Event Log
+
+## Timeline
+- 2026-02-26: 创建主任务 Issue [#26](https://github.com/gui16789/zpdAcademy/issues/26)
+- 2026-02-26: 创建子任务 Issue [#27](https://github.com/gui16789/zpdAcademy/issues/27) [#28](https://github.com/gui16789/zpdAcademy/issues/28) [#29](https://github.com/gui16789/zpdAcademy/issues/29) [#30](https://github.com/gui16789/zpdAcademy/issues/30)
+- 2026-02-26: 开始分支 `feat/DEV-20260226-005-score-history` 开发
+
+## Traceability
+- Task: DEV-20260226-005
+- Parent Issue: #26
+- Child Issues: #27 #28 #29 #30
+- Branch: `feat/DEV-20260226-005-score-history`
+- PR: 待创建
+
+## Stage Check
+- Stage 1: 已完成（澄清）
+- Stage 2: 已完成（设计与拆分）
+- Stage 3: 进行中（编码与测试）

--- a/docs/events/DEV-20260226-005-event-log.md
+++ b/docs/events/DEV-20260226-005-event-log.md
@@ -4,6 +4,7 @@
 - 2026-02-26: 创建主任务 Issue [#26](https://github.com/gui16789/zpdAcademy/issues/26)
 - 2026-02-26: 创建子任务 Issue [#27](https://github.com/gui16789/zpdAcademy/issues/27) [#28](https://github.com/gui16789/zpdAcademy/issues/28) [#29](https://github.com/gui16789/zpdAcademy/issues/29) [#30](https://github.com/gui16789/zpdAcademy/issues/30)
 - 2026-02-26: 开始分支 `feat/DEV-20260226-005-score-history` 开发
+- 2026-02-26: 提交 PR [#31](https://github.com/gui16789/zpdAcademy/pull/31)
 
 ## Traceability
 - Task: DEV-20260226-005
@@ -14,7 +15,8 @@
   - `bbd1e6a` feat(progress): 增加单元成绩记录与快照兼容
   - `546029b` feat(map): 展示单元成绩并联动答题结果
   - `d622fe7` test(docs): 补充成绩持久化测试与Task-005记录
-- PR: 待创建
+  - `63fc8c1` docs(event): 回写Task-005提交链路
+- PR: #31
 
 ## Stage Check
 - Stage 1: 已完成（澄清）

--- a/docs/tasks/DEV-20260226-005-score-history.md
+++ b/docs/tasks/DEV-20260226-005-score-history.md
@@ -54,4 +54,8 @@
 ## 流水线记录（GitHub）
 - 主任务 Issue：[#26](https://github.com/gui16789/zpdAcademy/issues/26)
 - 功能分支：`feat/DEV-20260226-005-score-history`
+- Commit：
+  - `bbd1e6a`（Sub-1, Sub-2）
+  - `546029b`（Sub-3）
+  - `d622fe7`（Sub-4）
 - Event Log：`docs/events/DEV-20260226-005-event-log.md`

--- a/docs/tasks/DEV-20260226-005-score-history.md
+++ b/docs/tasks/DEV-20260226-005-score-history.md
@@ -58,4 +58,6 @@
   - `bbd1e6a`（Sub-1, Sub-2）
   - `546029b`（Sub-3）
   - `d622fe7`（Sub-4）
+  - `63fc8c1`（traceability）
+- PR：[#31](https://github.com/gui16789/zpdAcademy/pull/31)
 - Event Log：`docs/events/DEV-20260226-005-event-log.md`

--- a/docs/tasks/DEV-20260226-005-score-history.md
+++ b/docs/tasks/DEV-20260226-005-score-history.md
@@ -1,0 +1,57 @@
+# DEV-20260226-005 · 单元成绩记录与地图展示
+
+## Stage 1 澄清结论
+1. 我的理解
+- 在答题闭环基础上，记录每个单元的成绩信息（最近得分/最高分/尝试次数）。
+- 地图页展示单元成绩卡片，便于用户看到学习轨迹。
+2. 边界确认
+- 成绩仍存储在 localStorage，不接后端。
+- 不做排行榜与跨用户对比。
+3. 依赖检查
+- 依赖 DEV-20260226-004 的题目页答题流程与判题结果。
+
+## Stage 2 设计与任务拆分
+
+### In Scope
+- 扩展进度快照结构（含成绩记录）。
+- 改造 progress store，支持提交答题结果并更新成绩。
+- 地图页显示单元成绩摘要。
+- 补充持久化兼容性与状态更新测试。
+
+### Out of Scope
+- 服务端成绩同步。
+- 图表统计与周/月趋势。
+- 复杂激励机制（徽章、等级）。
+
+### 子任务（每个 <= 2h）
+1. Sub-1 基建型：成绩模型与快照兼容（预计 45min）
+- 文件：`src/types/progress.ts`, `src/services/storage/progressStorage.ts`
+- 依赖：无
+- 验收：旧快照可兼容新结构。
+- Issue：[#27](https://github.com/gui16789/zpdAcademy/issues/27)
+2. Sub-2 功能型：progress store 成绩更新能力（预计 60min）
+- 文件：`src/store/progressStore.ts`
+- 依赖：Sub-1
+- 验收：提交答题后 attempts/lastScore/bestScore 更新正确。
+- Issue：[#28](https://github.com/gui16789/zpdAcademy/issues/28)
+3. Sub-3 集成型：Question/Map 页面联动展示（预计 90min）
+- 文件：`src/views/Question/QuestionPage.tsx`, `src/views/Map/MapPage.tsx`
+- 依赖：Sub-2
+- 验收：提交答题后地图可见成绩信息。
+- Issue：[#29](https://github.com/gui16789/zpdAcademy/issues/29)
+4. Sub-4 测试型：存储与评分记录回归测试（预计 45min）
+- 文件：`src/services/storage/progressStorage.test.ts`
+- 依赖：Sub-1
+- 验收：测试覆盖空值、坏值、正常值与兼容值。
+- Issue：[#30](https://github.com/gui16789/zpdAcademy/issues/30)
+
+## 风险与应对
+1. 风险：旧数据结构导致解析失败。
+- 应对：normalize 时提供默认值并严格校验字段。
+2. 风险：页面和 store 的状态源不一致。
+- 应对：QuestionPage 提交后统一走 store action。
+
+## 流水线记录（GitHub）
+- 主任务 Issue：[#26](https://github.com/gui16789/zpdAcademy/issues/26)
+- 功能分支：`feat/DEV-20260226-005-score-history`
+- Event Log：`docs/events/DEV-20260226-005-event-log.md`

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,6 +4,7 @@ export const TASK_ID = 'DEV-20260226-001'
 export const MAP_PROGRESS_TASK_ID = 'DEV-20260226-002'
 export const PROGRESS_PERSIST_TASK_ID = 'DEV-20260226-003'
 export const QUESTION_MVP_TASK_ID = 'DEV-20260226-004'
+export const SCORE_HISTORY_TASK_ID = 'DEV-20260226-005'
 export const PROGRESS_STORAGE_KEY = 'zpd-academy-progress-v1'
 
 export const ROUTES = {

--- a/src/services/storage/progressStorage.test.ts
+++ b/src/services/storage/progressStorage.test.ts
@@ -21,6 +21,9 @@ describe('progressStorage', () => {
     const snapshot = {
       completedUnitIds: ['unit-01', 'unit-02'],
       currentUnlockedIndex: 2,
+      unitScoreRecords: {
+        'unit-01': { attempts: 2, lastScore: 80, bestScore: 90 },
+      },
     }
 
     saveProgressSnapshot(snapshot)
@@ -38,11 +41,32 @@ describe('progressStorage', () => {
     const malformed = {
       completedUnitIds: ['unit-01', 5],
       currentUnlockedIndex: -2,
+      unitScoreRecords: {
+        'unit-01': {
+          attempts: -1,
+          lastScore: 120,
+          bestScore: 120,
+        },
+      },
     }
 
     expect(normalizeProgressSnapshot(malformed)).toEqual({
       completedUnitIds: [],
       currentUnlockedIndex: 0,
+      unitScoreRecords: {},
+    })
+  })
+
+  it('keeps compatibility with old snapshots without score records', () => {
+    const oldSnapshot = {
+      completedUnitIds: ['unit-02'],
+      currentUnlockedIndex: 1,
+    }
+
+    expect(normalizeProgressSnapshot(oldSnapshot)).toEqual({
+      completedUnitIds: ['unit-02'],
+      currentUnlockedIndex: 1,
+      unitScoreRecords: {},
     })
   })
 
@@ -50,6 +74,9 @@ describe('progressStorage', () => {
     saveProgressSnapshot({
       completedUnitIds: ['unit-01'],
       currentUnlockedIndex: 1,
+      unitScoreRecords: {
+        'unit-01': { attempts: 1, lastScore: 75, bestScore: 75 },
+      },
     })
 
     clearProgressSnapshot()

--- a/src/services/storage/progressStorage.ts
+++ b/src/services/storage/progressStorage.ts
@@ -1,5 +1,5 @@
 import { PROGRESS_STORAGE_KEY } from '../../config/constants'
-import type { ProgressSnapshot } from '../../types/progress'
+import type { ProgressSnapshot, UnitScoreRecord } from '../../types/progress'
 
 const DEFAULT_UNLOCKED_INDEX = 0
 
@@ -7,10 +7,42 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string')
 }
 
+function isValidScoreRecord(value: unknown): value is UnitScoreRecord {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as Partial<UnitScoreRecord>
+
+  return (
+    typeof candidate.attempts === 'number' &&
+    candidate.attempts >= 0 &&
+    typeof candidate.lastScore === 'number' &&
+    candidate.lastScore >= 0 &&
+    candidate.lastScore <= 100 &&
+    typeof candidate.bestScore === 'number' &&
+    candidate.bestScore >= 0 &&
+    candidate.bestScore <= 100
+  )
+}
+
+function normalizeUnitScoreRecords(value: unknown): Record<string, UnitScoreRecord> {
+  if (!value || typeof value !== 'object') {
+    return {}
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).filter((entry) =>
+    isValidScoreRecord(entry[1]),
+  )
+
+  return Object.fromEntries(entries) as Record<string, UnitScoreRecord>
+}
+
 export function getDefaultProgressSnapshot(): ProgressSnapshot {
   return {
     completedUnitIds: [],
     currentUnlockedIndex: DEFAULT_UNLOCKED_INDEX,
+    unitScoreRecords: {},
   }
 }
 
@@ -29,6 +61,7 @@ export function normalizeProgressSnapshot(value: unknown): ProgressSnapshot {
   return {
     completedUnitIds,
     currentUnlockedIndex,
+    unitScoreRecords: normalizeUnitScoreRecords(candidate.unitScoreRecords),
   }
 }
 

--- a/src/store/progressStore.ts
+++ b/src/store/progressStore.ts
@@ -10,7 +10,8 @@ import type { ProgressSnapshot } from '../types/progress'
 interface ProgressStoreState {
   completedUnitIds: string[]
   currentUnlockedIndex: number
-  markUnitCompleted: (unitId: string) => void
+  unitScoreRecords: ProgressSnapshot['unitScoreRecords']
+  submitUnitResult: (unitId: string, score: number, isPassed: boolean) => void
   resetProgress: () => void
 }
 
@@ -31,27 +32,45 @@ function persistSnapshot(snapshot: ProgressSnapshot): void {
   saveProgressSnapshot({
     completedUnitIds: snapshot.completedUnitIds,
     currentUnlockedIndex: clampUnlockedIndex(snapshot.currentUnlockedIndex),
+    unitScoreRecords: snapshot.unitScoreRecords,
   })
 }
 
 export const useProgressStore = create<ProgressStoreState>((set) => ({
   completedUnitIds: persistedSnapshot.completedUnitIds.filter((unitId) => unitIdSet.has(unitId)),
   currentUnlockedIndex: clampUnlockedIndex(persistedSnapshot.currentUnlockedIndex),
-  markUnitCompleted: (unitId) =>
+  unitScoreRecords: Object.fromEntries(
+    Object.entries(persistedSnapshot.unitScoreRecords).filter(([unitId]) => unitIdSet.has(unitId)),
+  ),
+  submitUnitResult: (unitId, score, isPassed) =>
     set((state) => {
-      const completedUnitIds = state.completedUnitIds.includes(unitId)
-        ? state.completedUnitIds
-        : [...state.completedUnitIds, unitId]
+      const safeScore = Math.max(0, Math.min(100, Math.round(score)))
+      const existingRecord = state.unitScoreRecords[unitId]
+      const nextRecord = {
+        attempts: (existingRecord?.attempts ?? 0) + 1,
+        lastScore: safeScore,
+        bestScore: Math.max(existingRecord?.bestScore ?? 0, safeScore),
+      }
+      const unitScoreRecords = {
+        ...state.unitScoreRecords,
+        [unitId]: nextRecord,
+      }
+
+      const completedUnitIds =
+        isPassed && !state.completedUnitIds.includes(unitId)
+          ? [...state.completedUnitIds, unitId]
+          : state.completedUnitIds
 
       const completedIndex = LEARNING_UNITS.findIndex((unit) => unit.id === unitId)
       const nextUnlockedIndex =
-        completedIndex >= state.currentUnlockedIndex
+        isPassed && completedIndex >= state.currentUnlockedIndex
           ? Math.min(completedIndex + 1, LEARNING_UNITS.length - 1)
           : state.currentUnlockedIndex
 
       const nextSnapshot = {
         completedUnitIds,
         currentUnlockedIndex: nextUnlockedIndex,
+        unitScoreRecords,
       }
 
       persistSnapshot(nextSnapshot)
@@ -63,6 +82,7 @@ export const useProgressStore = create<ProgressStoreState>((set) => ({
     set({
       completedUnitIds: [],
       currentUnlockedIndex: INITIAL_UNLOCKED_INDEX,
+      unitScoreRecords: {},
     })
   },
 }))

--- a/src/types/progress.ts
+++ b/src/types/progress.ts
@@ -12,7 +12,14 @@ export interface LearningUnitWithStatus extends LearningUnit {
   isActionable: boolean
 }
 
+export interface UnitScoreRecord {
+  attempts: number
+  lastScore: number
+  bestScore: number
+}
+
 export interface ProgressSnapshot {
   completedUnitIds: string[]
   currentUnlockedIndex: number
+  unitScoreRecords: Record<string, UnitScoreRecord>
 }

--- a/src/views/Map/MapPage.tsx
+++ b/src/views/Map/MapPage.tsx
@@ -5,6 +5,7 @@ import {
   MAP_PROGRESS_TASK_ID,
   PROGRESS_PERSIST_TASK_ID,
   ROUTES,
+  SCORE_HISTORY_TASK_ID,
   UI_CONFIG,
   buildQuestionRoute,
 } from '../../config/constants'
@@ -19,6 +20,7 @@ export function MapPage() {
   const clearUser = useUserStore((state) => state.clearUser)
   const completedUnitIds = useProgressStore((state) => state.completedUnitIds)
   const currentUnlockedIndex = useProgressStore((state) => state.currentUnlockedIndex)
+  const unitScoreRecords = useProgressStore((state) => state.unitScoreRecords)
   const resetProgress = useProgressStore((state) => state.resetProgress)
   const [feedback, setFeedback] = useState<string | null>(null)
 
@@ -70,6 +72,10 @@ export function MapPage() {
             {PROGRESS_PERSIST_TASK_ID}
           </span>
         </p>
+        <p className="mt-1 max-w-2xl text-base text-[color:var(--ink-muted)]">
+          成绩记录任务：
+          <span className="ml-1 font-semibold text-[color:var(--accent)]">{SCORE_HISTORY_TASK_ID}</span>
+        </p>
         <p className="mt-3 text-base text-[color:var(--ink-muted)]">
           进度：{completedCount} / {LEARNING_UNITS.length} 单元已完成
         </p>
@@ -77,46 +83,58 @@ export function MapPage() {
         {feedback ? <p className="mt-4 text-sm text-[color:var(--accent)]">{feedback}</p> : null}
 
         <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2">
-          {units.map((unit) => (
-            <article
-              key={unit.id}
-              className="rounded-2xl border border-[color:var(--stroke)] bg-[#0a1d3b]/70 p-5"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <h2 className="text-xl font-semibold">{unit.title}</h2>
-                <span
-                  className="rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wider"
-                  style={{
-                    backgroundColor:
-                      unit.status === 'completed'
-                        ? 'rgba(84,242,189,0.16)'
-                        : unit.status === 'unlocked'
-                          ? 'rgba(123,169,255,0.2)'
-                          : 'rgba(173,196,239,0.14)',
-                    color:
-                      unit.status === 'completed'
-                        ? '#54f2bd'
-                        : unit.status === 'unlocked'
-                          ? '#9ab9ff'
-                          : '#adc4ef',
-                  }}
-                >
-                  {unit.status}
-                </span>
-              </div>
-              <p className="mt-2 text-sm text-[color:var(--ink-muted)]">{unit.summary}</p>
-              <p className="mt-2 text-sm text-[color:var(--ink-muted)]">预计 {unit.durationMin} 分钟</p>
-              <button
-                type="button"
-                disabled={!unit.isActionable}
-                onClick={() => handleUnitAction(unit)}
-                className="mt-4 w-full rounded-xl border border-[color:var(--stroke)] px-4 text-base font-semibold transition enabled:hover:border-[color:var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
-                style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+          {units.map((unit) => {
+            const scoreRecord = unitScoreRecords[unit.id]
+
+            return (
+              <article
+                key={unit.id}
+                className="rounded-2xl border border-[color:var(--stroke)] bg-[#0a1d3b]/70 p-5"
               >
-                {getButtonLabel(unit)}
-              </button>
-            </article>
-          ))}
+                <div className="flex items-start justify-between gap-3">
+                  <h2 className="text-xl font-semibold">{unit.title}</h2>
+                  <span
+                    className="rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wider"
+                    style={{
+                      backgroundColor:
+                        unit.status === 'completed'
+                          ? 'rgba(84,242,189,0.16)'
+                          : unit.status === 'unlocked'
+                            ? 'rgba(123,169,255,0.2)'
+                            : 'rgba(173,196,239,0.14)',
+                      color:
+                        unit.status === 'completed'
+                          ? '#54f2bd'
+                          : unit.status === 'unlocked'
+                            ? '#9ab9ff'
+                            : '#adc4ef',
+                    }}
+                  >
+                    {unit.status}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-[color:var(--ink-muted)]">{unit.summary}</p>
+                <p className="mt-2 text-sm text-[color:var(--ink-muted)]">预计 {unit.durationMin} 分钟</p>
+                {scoreRecord ? (
+                  <p className="mt-2 text-xs text-[color:var(--ink-muted)]">
+                    尝试 {scoreRecord.attempts} 次 · 最近 {scoreRecord.lastScore} 分 · 最佳{' '}
+                    {scoreRecord.bestScore} 分
+                  </p>
+                ) : (
+                  <p className="mt-2 text-xs text-[color:var(--ink-muted)]">尚未作答</p>
+                )}
+                <button
+                  type="button"
+                  disabled={!unit.isActionable}
+                  onClick={() => handleUnitAction(unit)}
+                  className="mt-4 w-full rounded-xl border border-[color:var(--stroke)] px-4 text-base font-semibold transition enabled:hover:border-[color:var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+                  style={{ minHeight: UI_CONFIG.touchTargetMinPx }}
+                >
+                  {getButtonLabel(unit)}
+                </button>
+              </article>
+            )
+          })}
         </div>
 
         <div className="mt-8 flex flex-col gap-3 md:flex-row">

--- a/src/views/Question/QuestionPage.tsx
+++ b/src/views/Question/QuestionPage.tsx
@@ -10,7 +10,7 @@ export function QuestionPage() {
   const navigate = useNavigate()
   const { unitId } = useParams()
   const user = useUserStore((state) => state.user)
-  const markUnitCompleted = useProgressStore((state) => state.markUnitCompleted)
+  const submitUnitResult = useProgressStore((state) => state.submitUnitResult)
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [evaluation, setEvaluation] = useState<QuestionEvaluation | null>(null)
   const unit = LEARNING_UNITS.find((item) => item.id === unitId)
@@ -46,11 +46,12 @@ export function QuestionPage() {
       selectedOptionId: answers[question.id] ?? '',
     }))
 
-    setEvaluation(questionService.evaluateQuestions(questions, submissions))
+    const nextEvaluation = questionService.evaluateQuestions(questions, submissions)
+    submitUnitResult(activeUnit.id, nextEvaluation.score, nextEvaluation.isPassed)
+    setEvaluation(nextEvaluation)
   }
 
   function handleCompleteAndBack() {
-    markUnitCompleted(activeUnit.id)
     navigate(ROUTES.map)
   }
 


### PR DESCRIPTION
## 📋 关联需求
- Notion Task: DEV-20260226-005
- Parent Issue: #26

## 📝 变更说明
- 扩展 progress snapshot，新增单元成绩记录字段并兼容旧数据
- progress store 新增提交答题结果 action，维护 attempts/lastScore/bestScore
- QuestionPage 提交后直接写入成绩记录
- MapPage 卡片展示单元成绩摘要
- 补充存储兼容测试与任务事件记录

## ✅ 自检
- [x] npm run lint
- [x] npm run test
- [x] npm run build

## 🔗 关闭 Issues
Closes #26
Closes #27
Closes #28
Closes #29
Closes #30